### PR TITLE
Fix generated rows order

### DIFF
--- a/src/spreadsheet-templates.xsl
+++ b/src/spreadsheet-templates.xsl
@@ -84,15 +84,17 @@
     </xsl:element>
   </xsl:template>
   
+  
+  <xd:doc>
+    <xd:desc>
+      <xd:p>Process soox:data element to a sheetData element</xd:p>
+      <xd:p>Cells ar grouped in rows (in ascending order)</xd:p>
+    </xd:desc>
+  </xd:doc>
   <xsl:template match="s:data"  mode="soox:toOfficeOpenXml">
-    
-    <!--cols xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-      <col min="1" max="1" width="20.69921875" customWidth="1"/>
-      <col min="2" max="2" width="70.69921875" customWidth="1"/>
-    </cols-->
     <xsl:element name="sheetData" _namespace="{$ns-sml}">
       <xsl:for-each-group select="s:cell" group-by="@row" >
-        <xsl:sort select="current-grouping-key()" order="ascending"/>
+        <xsl:sort select="current-grouping-key()" order="ascending" data-type="number"/>
         <xsl:element name="row" _namespace="{$ns-sml}">
           <xsl:attribute name="r" select="current-grouping-key()"/>
           <!--xsl:attribute name="spans">1:2</xsl:attribute-->

--- a/tests/data/expected_sheet1.xml
+++ b/tests/data/expected_sheet1.xml
@@ -7,7 +7,7 @@
     <sheetPr filterMode="false">
         <pageSetUpPr fitToPage="false"/>
     </sheetPr>
-    <dimension ref="A1:B4"/>
+    <dimension ref="A1:B12"/>
     <sheetViews>
         <sheetView showFormulas="false" showGridLines="true" showRowColHeaders="true"
             showZeros="true" rightToLeft="false" tabSelected="true" showOutlineSymbols="true"
@@ -53,6 +53,12 @@
             </c>
             <c r="B4" s="1" t="n">
                 <v>-11741</v>
+            </c>
+        </row>
+        <row r="12" customFormat="false" ht="12.8" hidden="false" customHeight="false"
+            outlineLevel="0" collapsed="false">
+            <c r="B12" s="0" t="s">
+                <v>5</v>
             </c>
         </row>
     </sheetData>

--- a/tests/data/worksheet.xml
+++ b/tests/data/worksheet.xml
@@ -25,5 +25,8 @@
         <cell col="2" row="4">
             <v>1867-11-07</v>
         </cell>
+        <cell col="2" row="12">
+            <v>Line #12</v>
+        </cell>
     </data>
 </worksheet>

--- a/tests/spreadsheet-templates.xspec
+++ b/tests/spreadsheet-templates.xspec
@@ -9,7 +9,7 @@
     stylesheet="../src/spreadsheet-templates.xsl">
     
     
-    <x:variable name="x:saxon-config" href="../src/saxon.config"/>
+    <x:variable name="x:saxon-config" href="../src/saxon-HE.config"/>
 
     <x:helper stylesheet="helpers/helpers.xsl" />
     
@@ -17,8 +17,8 @@
         <x:variable name="my:worksheet" href="data/worksheet.xml"/>
         
         <x:scenario label="when templates are applied on it,">
-            <x:context select="$my:worksheet/element()" mode="soox:toOpenOffice" >
-                <x:param name="shared-strings" select="('nombre','chaine','toto','flottant','date')" tunnel="yes"/>
+            <x:context select="$my:worksheet/element()" mode="soox:toOfficeOpenXml" >
+                <x:param name="shared-strings" select="('nombre','chaine','toto','flottant','date','Line #12')" tunnel="yes"/>
             </x:context>
             
             <x:expect label="the computed range &lt;dimension&gt; should be as expected" href="data/expected_sheet1.xml"
@@ -35,6 +35,21 @@
             
             <x:expect label="all &lt;row&gt; (but dates row 4) should be as expected" href="data/expected_sheet1.xml"
                 select="xh:remove-whitespacesonly-nodes(.)/sml:worksheet/sml:sheetData/sml:row" test="/sml:worksheet/sml:sheetData/sml:row"/>
+        </x:scenario>
+        
+        <x:scenario label="when templates are applied on it,">
+            <x:context select="$my:worksheet/element()" mode="soox:toOfficeOpenXml" >
+                <x:param name="shared-strings" select="('nombre','chaine','toto','flottant','date','Line #12')" tunnel="yes"/>
+            </x:context>
+            
+            <x:expect label="the rows should be ordered in ascending order" as="attribute(r)*" 
+                test="//sml:row/@r" select="//sml:row/@r">
+                <sml:row r="1"/>
+                <sml:row r="2"/>
+                <sml:row r="3"/>
+                <sml:row r="4"/>
+                <sml:row r="12"/>
+            </x:expect>
         </x:scenario>
         
         <!--<x:scenario label="when xlwfile:worksheet.xml() is called on it," catch="yes">


### PR DESCRIPTION
Fix #5

Rows are now ordered using their numerical value (not the text value)